### PR TITLE
[Fix] Public key issue when update vscode via apt

### DIFF
--- a/install_vscode.sh
+++ b/install_vscode.sh
@@ -5,6 +5,12 @@ proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 apt update
 proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 wget https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.79.0-1686148160_arm64.deb -O code.deb
 proot-distro login debian --shared-tmp -- env DISPLAY=:1.0  sudo -S apt install ./code.deb -y
 proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 rm code.deb
+proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 sudo apt install gpg -y
+proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > packages.microsoft.gpg
+proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 sudo install -D -o root -g root -m 644 packages.microsoft.gpg /etc/apt/keyrings/packages.microsoft.gpg
+proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 sudo sh -c 'echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list'
+proot-distro login debian --shared-tmp -- env DISPLAY=:1.0 rm packages.microsoft.gpg
+
 
 echo "[Desktop Entry]
 Version=1.0


### PR DESCRIPTION
Fix vscode update issue when update via the app from apt

### Problem

![Screenshot_2023-09-12_01-42-52](https://github.com/phoenixbyrd/App-Installer/assets/11472121/aaf9e086-62ea-488e-ab19-b7f278048b38)

### Solution
This problem can be fixed by renewing sign key. I adding additional steps to vscode installation script with script provided by vscode setup guide (see reference)
![Screenshot_2023-09-12_01-44-10](https://github.com/phoenixbyrd/App-Installer/assets/11472121/b56ddd47-33af-4c13-bcc4-bd106bf0ab92)

### Reference
https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions